### PR TITLE
Fix Touchpad Mouse Mode option and touch gestures, fix building out-of-tree 

### DIFF
--- a/backends/events/switchsdl/switchsdl-events.h
+++ b/backends/events/switchsdl/switchsdl-events.h
@@ -58,7 +58,7 @@ private:
 		float lastDownY; // SDL touch coordinates when last pressed down
 	} Touch;
 
-	Touch _finger[SCE_TOUCH_PORT_MAX_NUM][MAX_NUM_FINGERS]; // keep track of finger status
+	Touch _finger[SCE_TOUCH_PORT_MAX_NUM][MAX_NUM_FINGERS] = {0}; // keep track of finger status
 
 	typedef enum DraggingType {
 		DRAG_NONE = 0,
@@ -66,9 +66,9 @@ private:
 		DRAG_THREE_FINGER,
 	} DraggingType;
 
-	DraggingType _multiFingerDragging[SCE_TOUCH_PORT_MAX_NUM]; // keep track whether we are currently drag-and-dropping
+	DraggingType _multiFingerDragging[SCE_TOUCH_PORT_MAX_NUM] = {0}; // keep track whether we are currently drag-and-dropping
 
-	unsigned int _simulatedClickStartTime[SCE_TOUCH_PORT_MAX_NUM][2]; // initiation time of last simulated left or right click (zero if no click)
+	unsigned int _simulatedClickStartTime[SCE_TOUCH_PORT_MAX_NUM][2] = {0}; // initiation time of last simulated left or right click (zero if no click)
 
 	void preprocessFingerDown(SDL_Event *event);
 	void preprocessFingerUp(SDL_Event *event);

--- a/backends/platform/sdl/switch/switch.mk
+++ b/backends/platform/sdl/switch/switch.mk
@@ -1,14 +1,14 @@
 residualvm.nro: $(EXECUTABLE)
 	mkdir -p ./switch_release/residualvm
 	nacptool --create "ResidualVM" "usineur" "$(VERSION)" ./switch_release/residualvm.nacp
-	elf2nro $(EXECUTABLE) ./switch_release/residualvm/residualvm.nro --icon=./dists/switch/icon.jpg --nacp=./switch_release/residualvm.nacp
+	elf2nro $(EXECUTABLE) ./switch_release/residualvm/residualvm.nro --icon=$(srcdir)/dists/switch/icon.jpg --nacp=./switch_release/residualvm.nacp
 
 residualvm_switch.zip: residualvm.nro
 	rm -f ./switch_release/residualvm.nacp
 	mkdir -p ./switch_release/residualvm/data
 	mkdir -p ./switch_release/residualvm/doc
-	cp ./backends/vkeybd/packs/vkeybd_default.zip ./switch_release/residualvm/data
-	cp ./backends/vkeybd/packs/vkeybd_small.zip ./switch_release/residualvm/data
+	cp $(srcdir)/backends/vkeybd/packs/vkeybd_default.zip ./switch_release/residualvm/data
+	cp $(srcdir)/backends/vkeybd/packs/vkeybd_small.zip ./switch_release/residualvm/data
 	cp $(DIST_FILES_THEMES) ./switch_release/residualvm/data
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) ./switch_release/residualvm/data


### PR DESCRIPTION
The structs used in touch controls were not zero-initialized. The compiler must be doing more aggressive optimizations here than in ScummVM, because they were filled with garbage data initially (in ScummVM they were filled with zeros, but no guaranteed I guess). This caused the Touchpad_Mouse_Mode option to not work correctly, and also touch gestures (tap to click, hold one finger, tap another to right click) to not work quite right.

I also made a change to use $srcdir in the makefile to allow building out-of-tree. 

E.g.
```
cd residualvm
mkdir ../buildswitch
cd ../buildswitch
../residualvm/configure --host=switch
make residualvm_switch.zip -j18
```
should now work as it did in ScummVM. Using an out-of-tree folder for building residualvm leaves the repo and source folders untouched.
