### PR TITLE
SWITCH: Fix touchpad_mouse_mode when compiling with newer SDL2

### DIFF
--- a/backends/events/switchsdl/switchsdl-events.cpp
+++ b/backends/events/switchsdl/switchsdl-events.cpp
@@ -50,6 +50,10 @@ SwitchSdlEventSource::SwitchSdlEventSource() {
 			_simulatedClickStartTime[port][i] = 0;
 		}
 	}
+#if SDL_VERSION_ATLEAST(2,0,10)
+	// ensure that touch doesn't create double-events
+	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+#endif
 }
 
 bool SwitchSdlEventSource::pollEvent(Common::Event &event) {


### PR DESCRIPTION
This is the real fix for touchpad_mouse_mode, when compiling with new-ish SDL2.